### PR TITLE
Incorrect check of query result

### DIFF
--- a/src/auth-service/server.py
+++ b/src/auth-service/server.py
@@ -23,10 +23,11 @@ def login():
     conn = get_db_connection()
     cur = conn.cursor()
     query = f"SELECT email, password FROM {auth_table_name} WHERE email = %s"
-    res = cur.execute(query, (auth.username,))
     
-    if res is None:
-        user_row = cur.fetchone()
+    cur.execute(query, (auth.username,))
+    user_row = cur.fetchone()
+
+    if user_row is not None:
         email = user_row[0]
         password = user_row[1]
 


### PR DESCRIPTION
the execute method of a cursor object in psycopg2 does not return any value and so it still runs fine but it still does not return a result that indicates whether the query was successful or not so setting it equal to res is pointless since it only executes the SQL command without providing result.
To determine if the query returned any result, you need to use the fetchone() or fetchall() methods after execute.